### PR TITLE
store-spec->client-opts dissociates :role-arn entry

### DIFF
--- a/src/io/mandoline/backend/dynamodb.clj
+++ b/src/io/mandoline/backend/dynamodb.clj
@@ -660,7 +660,9 @@
                             role-arn
                             session-name)
                   :else (DefaultAWSCredentialsProviderChain.))]
-    (merge store-spec {:provider provider})))
+    (-> store-spec
+      (dissoc :role-arn)
+      (merge {:provider provider}))))
 
 (defn root-table-prefix
   "Given a DynamoDBSchema root, construct a root prefix for naming the


### PR DESCRIPTION
This commit modifies the store-spec->client-opts function so that, if
the argument map contains a :role-arn entry, the returned map does not
contain a :role-arn entry. This behavior is desired because it ensures
that the function is idempotent over multiple applications.
