### PR TITLE
Log more info when throttled

### DIFF
--- a/src/io/mandoline/backend/dynamodb.clj
+++ b/src/io/mandoline/backend/dynamodb.clj
@@ -159,7 +159,7 @@
   faithfully returns binary attributes directly as ByteBuffer instances,
   bypassing Nippy deserialization."
   [client-opts table prim-kvs & [{:keys [attrs consistent? return-cc?]}]]
-  (ddbi/rethrow-aws-exception-with-table table
+  (ddbi/rethrow-aws-exception-with-info {:table table :key prim-kvs}
     (as-map*binary-safe
       (.getItem (#'far/db-client client-opts)
                 (doto-cond [g (GetItemRequest.)]
@@ -175,7 +175,7 @@
   bypassing Nippy serialization."
   [client-opts table item & [{:keys [return expected return-cc?]
                               :or   {return :none}}]]
-  (ddbi/rethrow-aws-exception-with-table table
+  (ddbi/rethrow-aws-exception-with-info {:table table :item item}
     (as-map*binary-safe
       (.putItem (#'far/db-client client-opts)
                 (doto-cond [g (PutItemRequest.)]
@@ -188,7 +188,7 @@
 (defn- query
   ; TODO binary-safe variant of the query function
   [client-opts table prim-key-conds & opts]
-  (ddbi/rethrow-aws-exception-with-table table
+  (ddbi/rethrow-aws-exception-with-info {:table table :key-conds prim-key-conds}
     (apply far/query client-opts table prim-key-conds opts)))
 
 (defn create-table

--- a/src/io/mandoline/backend/dynamodb/impl.clj
+++ b/src/io/mandoline/backend/dynamodb/impl.clj
@@ -2,15 +2,16 @@
   "A namespace for things we want to be private, but can't be tested privately
   (e.g. macros).")
 
-(defmacro rethrow-aws-exception-with-table
-  "Rethrow any AWS Exceptions with the table attached for easier debugging."
-  [table & body]
-  `(let [;; Evaluate the table expression immediately to help prevent it from
+(defmacro rethrow-aws-exception-with-info
+  "Rethrow any AWS Exceptions with the query info attached for easier
+  debugging."
+  [info & body]
+  `(let [;; Evaluate the info expression immediately to help prevent it from
          ;; producing errors that only happen when there's an Amazon exception.
-         table# ~table]
+         info# ~info]
      (try
        (do ~@body)
        (catch com.amazonaws.AmazonServiceException e#
          (throw (doto e#
-                  (.setErrorMessage (format "%s (DynamoDB table %s)"
-                                            (.getErrorMessage e#) table#))))))))
+                  (.setErrorMessage (format "%s (DynamoDB access %s)"
+                                            (.getErrorMessage e#) info#))))))))

--- a/test/io/mandoline/backend/dynamodb/impl_test.clj
+++ b/test/io/mandoline/backend/dynamodb/impl_test.clj
@@ -3,19 +3,19 @@
     [clojure.test :refer :all]
     [io.mandoline.backend.dynamodb.impl :as ddbi]))
 
-(deftest ^:unit test-rethrow-aws-exception-with-table
-  (testing "rethrow-aws-exception-with-table is sane"
+(deftest ^:unit test-rethrow-aws-exception-with-info
+  (testing "rethrow-aws-exception-with-info is sane"
     (is (= :result
-           (ddbi/rethrow-aws-exception-with-table "table"
+           (ddbi/rethrow-aws-exception-with-info {:table "table" :key :key}
              :ignored :result))))
-  (testing "rethrow-aws-exception-with-table rethrows"
+  (testing "rethrow-aws-exception-with-info rethrows"
     (is (thrown-with-msg? com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException
-          #".*message.*(DynamoDB table mytable).*"
-          (ddbi/rethrow-aws-exception-with-table "mytable"
+          #".*message.*(DynamoDB access \{:table \"mytable\", :key :key\}).*"
+          (ddbi/rethrow-aws-exception-with-info {:table "mytable" :key :key}
             (throw (com.amazonaws.services.dynamodbv2.model.ProvisionedThroughputExceededException.
                      "message"))))))
-  (testing "rethrow-aws-exception-with-table ignores other exceptions"
+  (testing "rethrow-aws-exception-with-info ignores other exceptions"
     (is (thrown-with-msg? NullPointerException #"^hi$"
-          (ddbi/rethrow-aws-exception-with-table "mytable"
+          (ddbi/rethrow-aws-exception-with-info {:table "mytable" :key :key}
             (throw (NullPointerException. "hi")))))))
 


### PR DESCRIPTION
Previously we only logged about what table got throttled; this changes it to log the DynamoDB query info, too.
